### PR TITLE
Allow custom auth via srp

### DIFF
--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -481,7 +481,8 @@ class CognitoUser {
       AuthenticationDetails authDetails) async {
     if (authenticationFlowType == 'USER_PASSWORD_AUTH') {
       return await _authenticateUserPlainUsernamePassword(authDetails);
-    } else if (authenticationFlowType == 'USER_SRP_AUTH') {
+    } else if (authenticationFlowType == 'USER_SRP_AUTH' ||
+			         authenticationFlowType == 'CUSTOM_AUTH') {
       return await _authenticateUserDefaultAuth(authDetails);
     }
     throw UnimplementedError('Authentication flow type is not supported.');


### PR DESCRIPTION
The custom authentication flow can be used with standard SRP password verification. The initial challenge is done using SRP and the custom authentication can provide MFA challenge such as email.

More information on this can be found here.
https://aws.amazon.com/blogs/mobile/extending-amazon-cognito-with-email-otp-for-2fa-using-amazon-ses/

The initial code migration captured this flow with all the appropriate methods in place. 
This PR just allows the CUSTOM_AUTH authentication flow to be run via the authenticateUser method.

```
authDetails = AuthenticationDetails(
  username: username,
  password: password,
);
cognitoUser.setAuthenticationFlowType('CUSTOM_AUTH');
cognitoUser.authenticateUser(authDetails)
```